### PR TITLE
Adds flagd pack

### DIFF
--- a/packs/flagd/README.md
+++ b/packs/flagd/README.md
@@ -59,7 +59,7 @@ This section describes Nomad-specific configuration.
 | Name                              | Description                                                   | Default |
 | --------------------------------- | ------------------------------------------------------------- | ------- |
 | nomad_group_count                 | Count of Deployments for the Group.                           | `1` |
-| nomad_group_ephemeral_disk        | Ephemeral Disk Configuration for the Group.                   | `{"migrate":true,"size":128,"sticky":true}` |
+| nomad_group_ephemeral_disk        | Ephemeral Disk Configuration for the Group.                   | `{"migrate":false,"size":16,"sticky":false}` |
 | nomad_group_name                  | Name for the Group.                                           | `"flagd"` |
 | nomad_group_network_mode          | Network Mode for the Group.                                   | `"host"` |
 | nomad_group_ports                 | Port Configuration for the Group.                             | `{"health":{"check_interval":"30s","check_timeout":"15s","host_network":null,"method":"GET","name":"health","omit_check":false,"path":"/healthz","port":8014,"type":"http"},"main":{"check_interval":"30s","check_timeout":"15s","host_network":null,"method":"POST","name":"main","omit_check":true,"path":"/","port":8013,"type":"http"}}` |

--- a/packs/flagd/README.md
+++ b/packs/flagd/README.md
@@ -59,7 +59,7 @@ This section describes Nomad-specific configuration.
 | Name                              | Description                                                   | Default |
 | --------------------------------- | ------------------------------------------------------------- | ------- |
 | nomad_group_count                 | Count of Deployments for the Group.                           | `1` |
-| nomad_group_ephemeral_disk        | Ephemeral Disk Configuration for the Group.                   | `{"migrate":false,"size":16,"sticky":false}` |
+| nomad_group_ephemeral_disk        | Ephemeral Disk Configuration for the Group.                   | `{"migrate":false,"size":128,"sticky":false}` |
 | nomad_group_name                  | Name for the Group.                                           | `"flagd"` |
 | nomad_group_network_mode          | Network Mode for the Group.                                   | `"host"` |
 | nomad_group_ports                 | Port Configuration for the Group.                             | `{"health":{"check_interval":"30s","check_timeout":"15s","host_network":null,"method":"GET","name":"health","omit_check":false,"path":"/healthz","port":8014,"type":"http"},"main":{"check_interval":"30s","check_timeout":"15s","host_network":null,"method":"POST","name":"main","omit_check":true,"path":"/","port":8013,"type":"http"}}` |

--- a/packs/flagd/README.md
+++ b/packs/flagd/README.md
@@ -1,0 +1,111 @@
+# Nomad Pack: OpenFeature flagd
+
+![Nomad Pack: OpenFeature flagd](https://assets.workloads.io/nomad-pack-registry/flagd.png)
+
+## Table of Contents
+
+<!-- TOC -->
+* [Nomad Pack: OpenFeature flagd](#nomad-pack-openfeature-flagd)
+  * [Table of Contents](#table-of-contents)
+  * [Requirements](#requirements)
+  * [Usage](#usage)
+      * [Application](#application)
+      * [Nomad](#nomad)
+    * [Outputs](#outputs)
+  * [Notes](#notes)
+  * [Author Information](#author-information)
+  * [License](#license)
+<!-- TOC -->
+
+## Requirements
+
+- HashiCorp Nomad `1.5.0` or newer
+- HashiCorp nomad-pack `0.0.1` or newer
+- Nomad Task Driver(s) for [`docker`](https://developer.hashicorp.com/nomad/docs/drivers/docker) or [`podman`](https://developer.hashicorp.com/nomad/plugins/drivers/podman)
+
+## Usage
+
+The `flagd` Pack can be run with a local fileset (commonly used when developing the Pack), or via the [@workloads Nomad Pack Registry](https://github.com/workloads/nomad-pack-registry).
+
+A Pack available _locally_ may be run like so:
+
+```shell
+nomad-pack run ./packs/flagd
+```
+
+A Pack available via the [@workloads Nomad Pack Registry](https://github.com/workloads/nomad-pack-registry) may be run like so:
+
+```shell
+# add the Pack Registry
+nomad-pack registry add workloads github.com/workloads/nomad-pack-registry
+
+# run the Pack
+nomad-pack run flagd --registry=workloads
+```
+
+<!-- BEGIN_PACK_DOCS -->
+
+#### Application
+
+This section describes Application-specific configuration.
+
+| Name             | Description           | Default |
+| ---------------- | --------------------- | ------- |
+| app_source_uri   | Source URI to serve.  | `"http:https://raw.githubusercontent.com/open-feature/flagd/main/samples/example_flags.flagd.json"` |
+
+#### Nomad
+
+This section describes Nomad-specific configuration.
+
+| Name                              | Description                                                   | Default |
+| --------------------------------- | ------------------------------------------------------------- | ------- |
+| nomad_group_count                 | Count of Deployments for the Group.                           | `1` |
+| nomad_group_ephemeral_disk        | Ephemeral Disk Configuration for the Group.                   | `{"migrate":true,"size":128,"sticky":true}` |
+| nomad_group_name                  | Name for the Group.                                           | `"flagd"` |
+| nomad_group_network_mode          | Network Mode for the Group.                                   | `"host"` |
+| nomad_group_ports                 | Port Configuration for the Group.                             | `{"health":{"check_interval":"30s","check_timeout":"15s","host_network":null,"name":"flagd_health","path":"/healthz","port":8014,"type":"http"},"main":{"check_interval":"30s","check_timeout":"15s","host_network":null,"name":"flagd_main","path":"/","port":8013,"type":"http"}}` |
+| nomad_group_restart_logic         | Restart Logic for the Group.                                  | `{"attempts":3,"delay":"30s","interval":"120s","mode":"fail"}` |
+| nomad_group_service_name_prefix   | Name of the Service for the Group.                            | `"flagd"` |
+| nomad_group_service_provider      | Provider of the Service for the Group.                        | `"nomad"` |
+| nomad_group_tags                  | List of Tags for the Group.                                   | `["flagd"]` |
+| nomad_group_volumes               | Volumes for the Group.                                        | `{"flagd_config":{"destination":"/etc/flagd","name":"flagd_config","read_only":false,"type":"host"}}` |
+| nomad_job_datacenters             | Eligible Datacenters for the Job.                             | `["*"]` |
+| nomad_job_name                    | Name for the Job.                                             | `"flagd"` |
+| nomad_job_namespace               | Namespace for the Job.                                        | `"default"` |
+| nomad_job_priority                | Priority for the Job.                                         | `10` |
+| nomad_job_region                  | Region for the Job.                                           | `"global"` |
+| nomad_pack_verbose_output         | Toggle to enable verbose output.                              | `true` |
+| nomad_task_args                   | Arguments to pass to the Task.                                | `["--config","/nomad/local/flagd.yml"]` |
+| nomad_task_command                | Command to pass to the Task.                                  | `"start"` |
+| nomad_task_driver                 | Driver to use for the Task.                                   | `"docker"` |
+| nomad_task_image                  | Content Address to use for the Container Image for the Task.  | `{"digest":"sha256:bc771a0e42089111784f06168238304212c9f22c9b472934de5d4bd742a09a81","image":"flagd","namespace":"open-feature","registry":"ghcr.io","tag":"v0.6.7"}` |
+| nomad_task_name                   | Name for the Task.                                            | `"flagd"` |
+| nomad_task_resources              | Resource Limits for the Task.                                 | `{"cores":null,"cpu":512,"memory":64,"memory_max":512}` |
+
+<!-- END_PACK_DOCS -->
+
+### Outputs
+
+For outputs, see [./outputs.tpl](./outputs.tpl).
+
+> **Note**
+>
+> The outputs are only rendered if `nomad_pack_verbose_output` is set to `true`.
+
+## Notes
+
+- By default, this Pack deploys a flagd instance with persistent storage. This requires one [Nomad Volume](https://developer.hashicorp.com/nomad/docs/job-specification/volume) to be configured. See the [test configuration](./tests/nomad_config.hcl) for an example.
+
+## Author Information
+
+This repository is maintained by the contributors listed on [GitHub](https://github.com/workloads/nomad-pack-registry/graphs/contributors).
+
+## License
+
+Licensed under the Apache License, Version 2.0 (the "License").
+
+You may obtain a copy of the License at [apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an _"AS IS"_ basis, without WARRANTIES or conditions of any kind, either express or implied.
+
+See the License for the specific language governing permissions and limitations under the License.

--- a/packs/flagd/README.md
+++ b/packs/flagd/README.md
@@ -107,6 +107,8 @@ nomad \
       "flags=$(curl https://raw.githubusercontent.com/open-feature/flagd/main/samples/example_flags.flagd.json)"
 ```
 
+The above example will force-write the content of [example_flags.flagd.json](https://raw.githubusercontent.com/open-feature/flagd/main/samples/example_flags.flagd.json) to the Nomad Variable `flags`, which is accessible to a Nomad Job named `flagd`.
+
 ## Author Information
 
 This repository is maintained by the contributors listed on [GitHub](https://github.com/workloads/nomad-pack-registry/graphs/contributors).

--- a/packs/flagd/README.md
+++ b/packs/flagd/README.md
@@ -49,9 +49,8 @@ nomad-pack run flagd --registry=workloads
 
 This section describes Application-specific configuration.
 
-| Name             | Description           | Default |
-| ---------------- | --------------------- | ------- |
-| app_source_uri   | Source URI to serve.  | `"http:https://raw.githubusercontent.com/open-feature/flagd/main/samples/example_flags.flagd.json"` |
+| Name | Description | Default |
+| -- | - | ------- |
 
 #### Nomad
 
@@ -63,24 +62,24 @@ This section describes Nomad-specific configuration.
 | nomad_group_ephemeral_disk        | Ephemeral Disk Configuration for the Group.                   | `{"migrate":true,"size":128,"sticky":true}` |
 | nomad_group_name                  | Name for the Group.                                           | `"flagd"` |
 | nomad_group_network_mode          | Network Mode for the Group.                                   | `"host"` |
-| nomad_group_ports                 | Port Configuration for the Group.                             | `{"health":{"check_interval":"30s","check_timeout":"15s","host_network":null,"name":"flagd_health","path":"/healthz","port":8014,"type":"http"},"main":{"check_interval":"30s","check_timeout":"15s","host_network":null,"name":"flagd_main","path":"/","port":8013,"type":"http"}}` |
+| nomad_group_ports                 | Port Configuration for the Group.                             | `{"health":{"check_interval":"30s","check_timeout":"15s","host_network":null,"method":"GET","name":"health","omit_check":false,"path":"/healthz","port":8014,"type":"http"},"main":{"check_interval":"30s","check_timeout":"15s","host_network":null,"method":"POST","name":"main","omit_check":true,"path":"/","port":8013,"type":"http"}}` |
 | nomad_group_restart_logic         | Restart Logic for the Group.                                  | `{"attempts":3,"delay":"30s","interval":"120s","mode":"fail"}` |
 | nomad_group_service_name_prefix   | Name of the Service for the Group.                            | `"flagd"` |
 | nomad_group_service_provider      | Provider of the Service for the Group.                        | `"nomad"` |
 | nomad_group_tags                  | List of Tags for the Group.                                   | `["flagd"]` |
-| nomad_group_volumes               | Volumes for the Group.                                        | `{"flagd_config":{"destination":"/etc/flagd","name":"flagd_config","read_only":false,"type":"host"}}` |
+| nomad_group_volumes               | Volumes for the Group.                                        | `{}` |
 | nomad_job_datacenters             | Eligible Datacenters for the Job.                             | `["*"]` |
 | nomad_job_name                    | Name for the Job.                                             | `"flagd"` |
 | nomad_job_namespace               | Namespace for the Job.                                        | `"default"` |
 | nomad_job_priority                | Priority for the Job.                                         | `10` |
 | nomad_job_region                  | Region for the Job.                                           | `"global"` |
 | nomad_pack_verbose_output         | Toggle to enable verbose output.                              | `true` |
-| nomad_task_args                   | Arguments to pass to the Task.                                | `["--config","/nomad/local/flagd.yml"]` |
+| nomad_task_args                   | Arguments to pass to the Task.                                | n/a |
 | nomad_task_command                | Command to pass to the Task.                                  | `"start"` |
 | nomad_task_driver                 | Driver to use for the Task.                                   | `"docker"` |
 | nomad_task_image                  | Content Address to use for the Container Image for the Task.  | `{"digest":"sha256:bc771a0e42089111784f06168238304212c9f22c9b472934de5d4bd742a09a81","image":"flagd","namespace":"open-feature","registry":"ghcr.io","tag":"v0.6.7"}` |
 | nomad_task_name                   | Name for the Task.                                            | `"flagd"` |
-| nomad_task_resources              | Resource Limits for the Task.                                 | `{"cores":null,"cpu":512,"memory":64,"memory_max":512}` |
+| nomad_task_resources              | Resource Limits for the Task.                                 | `{"cores":null,"cpu":500,"memory":64,"memory_max":512}` |
 
 <!-- END_PACK_DOCS -->
 
@@ -94,7 +93,19 @@ For outputs, see [./outputs.tpl](./outputs.tpl).
 
 ## Notes
 
-- By default, this Pack deploys a flagd instance with persistent storage. This requires one [Nomad Volume](https://developer.hashicorp.com/nomad/docs/job-specification/volume) to be configured. See the [test configuration](./tests/nomad_config.hcl) for an example.
+* flagd requires a feature flag definition to complete start-up.
+  This value is provided via the Nomad Variable `flags`, which is stored at `nomad/jobs/flagd`.
+
+* For testing purposes, a sample feature flag definition may be inserted like so:
+
+```shell
+nomad \
+  var \
+    put \
+      -force \
+      "nomad/jobs/flagd" \
+      "flags=$(curl https://raw.githubusercontent.com/open-feature/flagd/main/samples/example_flags.flagd.json)"
+```
 
 ## Author Information
 

--- a/packs/flagd/metadata.hcl
+++ b/packs/flagd/metadata.hcl
@@ -1,0 +1,10 @@
+app {
+  url = "https://flagd.dev"
+}
+
+pack {
+  name        = "flagd"
+  description = "A Nomad Pack for OpenFeature flagd"
+  url         = "https://github.com/workloads/nomad-pack-registry/tree/main/packs/flagd"
+  version     = "2.0.0"
+}

--- a/packs/flagd/outputs.tpl
+++ b/packs/flagd/outputs.tpl
@@ -44,7 +44,7 @@
 
 ## Service
 
-  Service Provider: `[[ var "service_provider" . ]]`
+  Service Provider: `[[ var "nomad_group_service_provider" . ]]`
   Service Name:     `[[ var "nomad_job_name" . | replace "_" "-" | trunc 63 | quote ]]`
 
   Service Tags:
@@ -55,7 +55,7 @@
 ## Application Configuration
 
 ```env
-[[- template "configuration" . ]]
+This Pack does not have any application-specific configuration.
 ```
 
 [[ end -]]

--- a/packs/flagd/outputs.tpl
+++ b/packs/flagd/outputs.tpl
@@ -1,0 +1,61 @@
+[[- if var "nomad_pack_verbose_output" . ]]
+# Job: _[[ var "nomad_job_name" . ]]_ (`v[[ meta "pack.version" . ]]`)
+
+  Region:    `[[ var "nomad_job_region" . ]]`
+  DC(s):     `[[ var "nomad_job_datacenters" . | toJson ]]`
+  Namespace: `[[ var "nomad_job_namespace" . ]]`
+  Name:      `[[ var "nomad_job_name" . ]]`
+  Count:     `[[ var "nomad_group_count" . ]]`
+
+## Image
+
+  Registry:  `[[ var "nomad_task_image.registry" . ]]`
+  Namespace: `[[ var "nomad_task_image.namespace" . ]]`
+  Image:     `[[ var "nomad_task_image.image" . ]]:[[ var "nomad_task_image.tag" . ]]`
+  Digest:    `[[ var "nomad_task_image.digest" . ]]`
+
+  [[- /* pretty-print Image information */]]
+  [[- if eq (var "nomad_task_image.registry" . ) "index.docker.io" ]]
+  URL:       https://hub.docker.com/layers/[[ var "nomad_task_image.namespace" . ]]/[[ var "nomad_task_image.image" . ]]/[[ var "nomad_task_image.tag" . ]]/images/[[ var "nomad_task_image.digest" . | replace ":" "-" ]]
+  [[ else ]]
+  URL:       https://[[ var "nomad_task_image.registry" . ]]/[[ var "nomad_task_image.namespace" . ]]/[[ var "nomad_task_image.image" . ]]:[[ var "nomad_task_image.tag" . ]]
+  [[ end ]]
+
+## Ports
+
+  [[- /* remove `rcon` from `$ports` if `var "app_enable_rcon" .` is false */]]
+  [[- $ports := var "nomad_group_ports" . ]]
+  [[- range $name, $config := $ports ]]
+  - `[[ $name ]]`: `[[ $config.port ]]` (type: `[[ $config.type ]]` [[ if and (eq $config.type "http") (eq $config.protocol "https") ]]protocol: `https`[[ end ]])
+  [[- end ]]
+
+## Resources
+
+  CPU:    [[ var "nomad_task_resources.cpu" . ]] MHz
+  Memory: [[ var "nomad_task_resources.memory" . ]] MB
+
+[[- if var "nomad_group_volumes" . ]]
+## Volumes
+
+  [[- range $name, $mounts := var "nomad_group_volumes" . ]]
+  - `[[ $mounts.name ]]` = `[[ $mounts.destination | toPrettyJson ]]` (type: `[[ $mounts.type ]]`[[ if $mounts.read_only ]], read-only[[ end ]])
+  [[- end ]]
+[[ end ]]
+
+## Service
+
+  Service Provider: `[[ var "service_provider" . ]]`
+  Service Name:     `[[ var "nomad_job_name" . | replace "_" "-" | trunc 63 | quote ]]`
+
+  Service Tags:
+    [[- range $name := var "nomad_group_tags" . ]]
+    - `[[ $name ]]`
+    [[- end ]]
+
+## Application Configuration
+
+```env
+[[- template "configuration" . ]]
+```
+
+[[ end -]]

--- a/packs/flagd/outputs.tpl
+++ b/packs/flagd/outputs.tpl
@@ -23,7 +23,6 @@
 
 ## Ports
 
-  [[- /* remove `rcon` from `$ports` if `var "app_enable_rcon" .` is false */]]
   [[- $ports := var "nomad_group_ports" . ]]
   [[- range $name, $config := $ports ]]
   - `[[ $name ]]`: `[[ $config.port ]]` (type: `[[ $config.type ]]` [[ if and (eq $config.type "http") (eq $config.protocol "https") ]]protocol: `https`[[ end ]])

--- a/packs/flagd/outputs.tpl
+++ b/packs/flagd/outputs.tpl
@@ -51,10 +51,4 @@
     - `[[ $name ]]`
     [[- end ]]
 
-## Application Configuration
-
-```env
-This Pack does not have any application-specific configuration.
-```
-
 [[ end -]]

--- a/packs/flagd/templates/_configuration.tpl
+++ b/packs/flagd/templates/_configuration.tpl
@@ -1,0 +1,15 @@
+[[/* format all `app_` variables in the best-possible way */]]
+[[- define "configuration" ]]
+  [[- range $name, $value := vars . -]]
+    [[ if and ($name | hasPrefix "app_") (printf "%v" $value) ]]
+      [[- $clean_name := $name | trimPrefix "app_" | upper ]]
+      [[- if (eq "slice" (kindOf $value)) ]]
+        [[ $clean_name ]] = "[[ $value | toStrings | join " " ]]"
+      [[- else if (or (eq "int" (kindOf $value)) (eq "bool" (kindOf $value))) ]]
+        [[ $clean_name ]] = "[[ $value ]]"
+      [[- else ]]
+        [[ $clean_name ]] = [[ $value | toString | quote ]]
+      [[- end ]]
+    [[- end ]]
+  [[- end ]]
+[[- end ]]

--- a/packs/flagd/templates/pack.nomad.tpl
+++ b/packs/flagd/templates/pack.nomad.tpl
@@ -1,0 +1,140 @@
+[[- $ports := var "nomad_group_ports" . ]]
+
+# see https://developer.hashicorp.com/nomad/docs/job-specification/job
+job "[[ var "nomad_job_name" . ]]" {
+  region      = "[[ var "nomad_job_region" . ]]"
+  datacenters = [[ var "nomad_job_datacenters" . | toJson ]]
+  type        = "service"
+  namespace   = "[[ var "nomad_job_namespace" . ]]"
+  priority    = [[ var "nomad_job_priority" . ]]
+
+  # see https://developer.hashicorp.com/nomad/docs/job-specification/group
+  group "[[ var "nomad_group_name" . ]]" {
+    count = [[ var "nomad_group_count" . ]]
+
+    # see https://developer.hashicorp.com/nomad/docs/job-specification/ephemeral_disk
+    ephemeral_disk {
+      [[- $ephemeral_disk := var "nomad_group_ephemeral_disk" . ]]
+      migrate = [[ $ephemeral_disk.migrate ]]
+      size    = [[ $ephemeral_disk.size ]]
+      sticky  = [[ $ephemeral_disk.sticky ]]
+    }
+
+    # see https://developer.hashicorp.com/nomad/docs/job-specification/network
+    network {
+      # see https://developer.hashicorp.com/nomad/docs/job-specification/network#network-modes
+      mode = "[[ var "nomad_group_network_mode" . ]]"
+
+      [[/* iterate over `$ports` to create Port Mappings */]]
+      [[- range $name, $config := $ports ]]
+      port "[[ $name ]]" {
+        static       = [[ $config.port ]]
+        to           = [[ $config.port ]]
+        [[- if $config.host_network ]]
+        host_network = "[[ $config.host_network ]]"
+        [[- end ]]
+      }
+      [[ end ]]
+    }
+
+    [[- $job_tags := var "nomad_group_tags" . -]]
+    [[- $service_name := var "nomad_group_service_name_prefix" . -]]
+    [[- $service_provider := var "nomad_group_service_provider" . -]]
+    [[/* iterate over `$ports` to map Services */]]
+    [[ range $name, $port := $ports ]]
+    # see https://developer.hashicorp.com/nomad/docs/job-specification/service
+    service {
+      name     = "[[ $service_name | replace "_" "-" | trunc 20 ]]-[[ $name | replace "_" "-" | trunc 43 ]]"
+      tags     = [[ $job_tags | toJson ]]
+      port     = [[ $port.port ]]
+      provider = "[[ $service_provider ]]"
+
+      # see https://developer.hashicorp.com/nomad/docs/job-specification/check
+      check {
+        name     = "[[ $name ]]"
+        type     = "[[ $port.type ]]"
+        [[- if eq $port.type "http" ]]
+        path     = "[[ $port.path ]]"
+        [[- end ]]
+        interval = "[[ $port.check_interval ]]"
+        timeout  = "[[ $port.check_timeout ]]"
+      }
+    }
+    [[ end ]]
+
+    # see https://developer.hashicorp.com/nomad/docs/job-specification/restart
+    restart {
+      [[- $restart_logic := var "nomad_group_restart_logic" . ]]
+      attempts = [[ $restart_logic.attempts ]]
+      interval = "[[ $restart_logic.interval ]]"
+      delay    = "[[ $restart_logic.delay ]]"
+      mode     = "[[ $restart_logic.mode ]]"
+    }
+
+    # see https://developer.hashicorp.com/nomad/docs/job-specification/volume
+    [[/* iterate over `var.volumes` to create Volumes */]]
+    [[- range $index, $mount := var "nomad_group_volumes" . ]]
+    volume "[[ $mount.name ]]" {
+      source    = "[[ $mount.name ]]"
+      type      = "[[ $mount.type ]]"
+      read_only = [[ $mount.read_only ]]
+    }
+    [[ end ]]
+
+    # see https://developer.hashicorp.com/nomad/docs/job-specification/task
+    task "[[ var "nomad_task_name" . ]]" {
+      # see https://developer.hashicorp.com/nomad/docs/drivers
+      driver = "[[ var "nomad_task_driver" . ]]"
+
+      # see https://developer.hashicorp.com/nomad/docs/drivers/docker
+      # and https://developer.hashicorp.com/nomad/plugins/drivers/podman
+      config {
+        [[- $image := var "nomad_task_image" . ]]
+        image = "[[ $image.registry ]]/[[ $image.namespace ]]/[[ $image.image ]]:[[ $image.tag ]]@[[ $image.digest ]]"
+
+        # see https://developer.hashicorp.com/nomad/docs/drivers/docker#command
+        command = "[[ var "nomad_task_command" . ]]"
+
+        # see https://developer.hashicorp.com/nomad/docs/drivers/docker#args
+        args = [[ var "nomad_task_args" . | toJson ]]
+
+        # see https://developer.hashicorp.com/nomad/docs/drivers/docker#ports
+        # and https://developer.hashicorp.com/nomad/plugins/drivers/podman#ports
+        ports = [
+          [[- range $name, $port := $ports ]]
+          "[[ $name ]]",
+          [[- end ]]
+        ]
+      }
+
+      # see https://developer.hashicorp.com/nomad/docs/job-specification/env
+      env {
+        [[- template "configuration" . ]]
+      }
+
+      # see https://developer.hashicorp.com/nomad/docs/job-specification/volume_mount
+      [[/* iterate over `var.volumes` to create Volume Mounts */]]
+      [[- range $index, $mount := var "nomad_group_volumes" . ]]
+      volume_mount {
+          volume      = "[[ $mount.name ]]"
+          destination = "[[ $mount.destination ]]"
+          read_only   = [[ $mount.read_only ]]
+      }
+      [[ end ]]
+
+      # see https://developer.hashicorp.com/nomad/docs/job-specification/resources
+      resources {
+        [[- $resources := var "nomad_task_resources" . ]]
+        cpu        = [[ $resources.cpu ]]
+        cores      = [[ $resources.cores | default "null" ]]
+        memory     = [[ $resources.memory ]]
+
+        # TODO: add support for memory oversubscription
+        # memory_max = [[ $resources.memory_max ]]
+      }
+    }
+  }
+}
+
+[[/* add diagnostic information to bottom of job-spec */]]
+# generated by `[[ env "USER" ]]` on [[ now | date "2006-01-01 at 15:04:05" ]]

--- a/packs/flagd/templates/pack.nomad.tpl
+++ b/packs/flagd/templates/pack.nomad.tpl
@@ -112,11 +112,6 @@ job "[[ var "nomad_job_name" . ]]" {
         ]
       }
 
-      # see https://developer.hashicorp.com/nomad/docs/job-specification/env
-      env {
-        # The flagd Pack does not currently use any environment variables
-      }
-
       # see https://developer.hashicorp.com/nomad/docs/job-specification/template
       template {
         change_mode = "noop"

--- a/packs/flagd/templates/pack.nomad.tpl
+++ b/packs/flagd/templates/pack.nomad.tpl
@@ -48,7 +48,7 @@ job "[[ var "nomad_job_name" . ]]" {
     service {
       name     = "[[ $service_name | replace "_" "-" | trunc 20 ]]-[[ $name | replace "_" "-" | trunc 43 ]]"
       tags     = [[ $job_tags | toJson ]]
-      port     = "[[ $port.name ]]"
+      port     = "[[ $name ]]"
       provider = "[[ $service_provider ]]"
 
       [[ if eq $port.omit_check false ]]

--- a/packs/flagd/tests/config.mk
+++ b/packs/flagd/tests/config.mk
@@ -1,2 +1,2 @@
 # directories to create before starting
-TEST_DIRECTORIES = "/tmp/flagd_config"
+TEST_DIRECTORIES =

--- a/packs/flagd/tests/config.mk
+++ b/packs/flagd/tests/config.mk
@@ -1,0 +1,2 @@
+# directories to create before starting
+TEST_DIRECTORIES = "/tmp/flagd_config"

--- a/packs/flagd/tests/gitignored_spec.nv.sample.hcl
+++ b/packs/flagd/tests/gitignored_spec.nv.sample.hcl
@@ -1,0 +1,17 @@
+# The root-level Makefile will automatically map these variables this file if it is renamed to `gitignored_spec.nv.hcl`.
+# This file may be used to set sensitive variables for testing purposes.
+
+items {
+  flags = {
+    "flags": {
+      "myBoolFlag": {
+        "state": "ENABLED",
+        "variants": {
+          "on": true,
+          "off": false
+        },
+        "defaultVariant": "on"
+      },
+    }
+  }
+}

--- a/packs/flagd/tests/newman.json
+++ b/packs/flagd/tests/newman.json
@@ -1,0 +1,447 @@
+{
+	"info": {
+		"_postman_id": "c81edc25-f052-41a7-930e-e7ded9aa3714",
+		"name": "minecraft_bedrock_edition",
+		"description": "# Nomad Pack: flagd\n\n> [Postman Collection](https://learning.postman.com/docs/collections/collections-overview/) containing API tests to run against the Nomad API. \n  \n\n## Notes\n\n- This Collection is designed for testing the `minecraft_bedrock_edition` Pack available at [@workloads/nomad-pack-registry](https://github.com/workloads/nomad-pack-registry/tree/main/packs/minecraft_bedrock_edition).\n\n- This Collection expects Nomad to be available via `http://localhost:4646`.",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "20135",
+		"_collection_link": "https://wrklds.postman.co/workspace/Team-Workspace~6bd90753-17de-4e29-86da-52ea739451c8/collection/20135-c81edc25-f052-41a7-930e-e7ded9aa3714?action=share&creator=20135&source=collection_link"
+	},
+	"item": [
+		{
+			"name": "nomad-selfcheck",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"// map Postman Response Object to variable after parsing it as JSON",
+							"var res = pm.response.json();",
+							"res = res.config;",
+							"",
+							"// define test data, taking care to map it as closely to Nomad configuration syntax as possible",
+							"const config = {",
+							"  ACL: {",
+							"    Enabled: false,",
+							"  },",
+							"",
+							"  Client: {",
+							"    Enabled: true,",
+							"    NomadServiceDiscovery: true,",
+							"",
+							"    HostVolumes: [",
+							"        {",
+							"          Name: 'minecraft_bedrock_data',",
+							"          Path: '/tmp/minecraft_bedrock_data',",
+							"          ReadOnly: false,",
+							"        }",
+							"      ],",
+							"",
+							"      Options: {",
+							"        driver: {",
+							"          allowlist: 'docker,podman',",
+							"        },",
+							"      },",
+							"    },",
+							"",
+							"  Datacenter: pm.collectionVariables.get('datacenter'),",
+							"  DevMode: true,",
+							"  File: 'packs/' + pm.collectionVariables.get('pack') + '/tests/nomad_config.hcl',",
+							"",
+							"  Plugins: [",
+							"    {",
+							"      Name: 'docker',",
+							"    },",
+							"  ],",
+							"",
+							"  Region: pm.collectionVariables.get('region'),",
+							"",
+							"  UI: {",
+							"    Enabled: true,",
+							"  },",
+							"};",
+							"",
+							"pm.test('root configuration', function () {",
+							"  pm.expect(res.Datacenter).to.eql(config.Datacenter);",
+							"  pm.expect(res.DevMode).to.eql(config.DevMode);",
+							"  pm.expect(res.Files).to.contain(config.File);",
+							"  pm.expect(res.Region).to.eql(config.Region);",
+							"});",
+							"",
+							"pm.test('`acl` configuration', function () {",
+							"  pm.expect(res.ACL.Enabled).to.eql(config.ACL.Enabled);",
+							"});",
+							"",
+							"pm.test('`client` configuration', function () {",
+							"  pm.expect(res.Client.Enabled).to.eql(config.Client.Enabled);",
+							"  pm.expect(res.Client.HostVolumes.length).to.eql(config.Client.HostVolumes.length);",
+							"  pm.expect(res.Client.HostVolumes).to.eql(config.Client.HostVolumes);",
+							"  pm.expect(res.Client.NomadServiceDiscovery).to.eql(config.Client.NomadServiceDiscovery);",
+							"  pm.expect(res.Client.Options['driver.allowlist']).to.eql(config.Client.Options.driver.allowlist);",
+							"});",
+							"",
+							"pm.test('`plugins` configuration', function () {",
+							"  pm.expect(res.Plugins[0].Name).to.eql(config.Plugins[0].Name);",
+							"});",
+							"",
+							"pm.test('`ui` configuration', function () {",
+							"  pm.expect(res.UI.Enabled).to.eql(config.UI.Enabled);",
+							"  pm.expect(res.UI.Label).to.be.an('object').and.not.be.empty;",
+							"});",
+							"",
+							"postman.setNextRequest('nomad-job');"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{nomad_server}}/v1/agent/self",
+					"host": [
+						"{{nomad_server}}"
+					],
+					"path": [
+						"v1",
+						"agent",
+						"self"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "nomad-job",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"// map Postman Response Object to variable after parsing it as JSON",
+							"const res = pm.response.json();",
+							"",
+							"// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
+							"const config = {",
+							"  EphemeralDisk: {",
+							"    Sticky: true,",
+							"    SizeMB: 1024",
+							"  },",
+							"",
+							"  ID: pm.collectionVariables.get('job_name'),",
+							"  Namespace: pm.collectionVariables.get('namespace'),",
+							"  Priority: 99,",
+							"  Region: pm.collectionVariables.get('region'),",
+							"  ",
+							"  ReservedPorts: [",
+							"    {",
+							"      Label: 'main',",
+							"      Value: 19132,",
+							"      To: 19132,",
+							"      HostNetwork: 'default'",
+							"    },",
+							"  ],",
+							"",
+							"  ServicesCount: 1,",
+							"  Status: 'running'",
+							"};",
+							"",
+							"pm.test('root response', function () {",
+							"  pm.expect(res.ID).to.eql(config.ID);",
+							"  pm.expect(res.Namespace).to.eql(config.Namespace);",
+							"  pm.expect(res.Priority).to.eql(config.Priority);",
+							"  pm.expect(res.Region).to.eql(config.Region);",
+							"  pm.expect(res.Status).to.eql(config.Status);",
+							"});",
+							"",
+							"pm.test('`TaskGroups.EphemeralDisk` response', function () {",
+							"  pm.expect(res.TaskGroups[0].EphemeralDisk.Sticky).to.eql(config.EphemeralDisk.Sticky);",
+							"  pm.expect(res.TaskGroups[0].EphemeralDisk.SizeMB).to.eql(config.EphemeralDisk.SizeMB);",
+							"});",
+							"",
+							"// set collection variable for each service, containing provider",
+							"for (taskGroup of res.TaskGroups[0].Services) {",
+							"  pm.collectionVariables.set('service_provider_' + taskGroup.Name, taskGroup.Provider);",
+							"}",
+							"",
+							"pm.test('`TaskGroups.Networks` response', function () {",
+							"  pm.expect(res.TaskGroups[0].Networks[0].ReservedPorts).to.eql(config.ReservedPorts);",
+							"});",
+							"",
+							"pm.test('`TaskGroups.Services` response', function () {",
+							"  pm.expect(res.TaskGroups[0].Services.length).to.eql(config.ServicesCount);",
+							"});",
+							"",
+							"// pm.test('status is stable', function () {",
+							"//   pm.expect(res.Stable).to.eql(true);",
+							"// });",
+							"",
+							"postman.setNextRequest('nomad-allocation');"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableCookies": false
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{nomad_server}}/v1/job/{{job_name}}",
+					"host": [
+						"{{nomad_server}}"
+					],
+					"path": [
+						"v1",
+						"job",
+						"{{job_name}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "nomad-allocation",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.log('pre', 'Collection Variable `job_name` = `' + pm.collectionVariables.get('job_name') + '`');",
+							"",
+							"// clear previously-set `service_name` variable",
+							"pm.collectionVariables.unset('service_name');"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"// map Postman Response Object to variable after parsing it as JSON",
+							"var res = pm.response.json();",
+							"res = res[0];",
+							"",
+							"// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
+							"const config = {",
+							"  ClientStatus: 'running',",
+							"  ",
+							"  // use environment variable as set in the `nomad-job` request",
+							"  JobID: pm.collectionVariables.get('job_name'),",
+							"  Namespace: pm.collectionVariables.get('namespace')",
+							"};",
+							"",
+							"pm.test('root response', function () {",
+							"  pm.expect(res.ClientStatus).to.eql(config.ClientStatus);",
+							"  pm.expect(res.JobID).to.eql(config.JobID);",
+							"  pm.expect(res.Namespace).to.eql(config.Namespace);",
+							"});",
+							"",
+							"pm.test('`TaskStates` response', function () {",
+							"  pm.expect(res.TaskStates[config.JobID].Failed).to.eql(false);",
+							"});",
+							"",
+							"pm.test('`DeploymentStatus` response', function () {",
+							"  pm.expect(res.DeploymentStatus.Healthy).to.eql(true);",
+							"});",
+							"",
+							"// set Collection Variable `job_name` for downstream use",
+							"// replace all underscores with dashes, as per logic inside Pack template",
+							"pm.collectionVariables.set('service_name', res.JobID.split('_').join('-'));",
+							"pm.log('main', 'Collection Variable `service_name` = `' + pm.collectionVariables.get('service_name') + '`');"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableCookies": false
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{nomad_server}}/v1/job/{{job_name}}/allocations",
+					"host": [
+						"{{nomad_server}}"
+					],
+					"path": [
+						"v1",
+						"job",
+						"{{job_name}}",
+						"allocations"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "nomad-service-main",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"const service_name = pm.collectionVariables.get('service_name');",
+							"const service_provider = pm.collectionVariables.get('service_provider_' + service_name + '-main')",
+							"",
+							"pm.log('pre', 'Collection Variable `service_name` = `' + service_name + '`');",
+							"pm.log('pre', 'Collection Variable `service_provider` = `' + service_provider + '`');",
+							"",
+							"",
+							"// check if provider is `nomad`, or skip the test:",
+							"if (service_provider == 'consul') {",
+							"  pm.log('pre', 'Service Provider is Consul, skipping test');",
+							"",
+							"  // TODO: build logic to skip test",
+							"}"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
+							"const config = {",
+							"  Datacenter: pm.collectionVariables.get('datacenter'),",
+							"  JobID: pm.collectionVariables.get('job_name'),",
+							"  Namespace: pm.collectionVariables.get('namespace'),",
+							"  Port: 19132,",
+							"",
+							"  // use environment variable as set in the `nomad-allocation` request",
+							"  ServiceName: pm.collectionVariables.get('service_name') + '-main',",
+							"",
+							"  Tags: [",
+							"    'minecraft',",
+							"    'minecraft-bedrock-edition',",
+							"  ]",
+							"};",
+							"",
+							"// map Postman Response Object to variable after parsing it as JSON",
+							"var res = pm.response.json();",
+							"res = res[0];",
+							"",
+							"pm.test('root response', function () {",
+							"  pm.expect(res.Datacenter).to.eql(config.Datacenter);",
+							"  pm.expect(res.JobID).to.eql(config.JobID);",
+							"  pm.expect(res.Namespace).to.eql(config.Namespace);  ",
+							"  pm.expect(res.Port).to.eql(config.Port);",
+							"  pm.expect(res.ServiceName).to.eql(config.ServiceName);",
+							"  pm.expect(res.Tags).to.eql(config.Tags);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableCookies": false
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{nomad_server}}/v1/service/{{service_name}}-main",
+					"host": [
+						"{{nomad_server}}"
+					],
+					"path": [
+						"v1",
+						"service",
+						"{{service_name}}-main"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"Object.prototype.log = (stage, message) => {",
+					"  // add collection and request names as prefix:",
+					"  var prefix = '[' + pm.collectionVariables.get('pack') + ':' + pm.info.requestName + `:${stage}] `;",
+					"",
+					"  console.info(prefix + `${message}`);",
+					"};"
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "datacenter",
+			"value": "testing",
+			"type": "string"
+		},
+		{
+			"key": "job_name",
+			"value": "minecraft",
+			"type": "string"
+		},
+		{
+			"key": "namespace",
+			"value": "default",
+			"type": "string"
+		},
+		{
+			"key": "nomad_server",
+			"value": "http://localhost:4646",
+			"type": "string"
+		},
+		{
+			"key": "pack",
+			"value": "minecraft_bedrock_edition",
+			"type": "string"
+		},
+		{
+			"key": "region",
+			"value": "global",
+			"type": "string"
+		},
+		{
+			"key": "service_provider_minecraft-main",
+			"value": ""
+		},
+		{
+			"key": "service_name",
+			"value": ""
+		}
+	]
+}

--- a/packs/flagd/tests/newman.json
+++ b/packs/flagd/tests/newman.json
@@ -1,447 +1,611 @@
 {
-	"info": {
-		"_postman_id": "c81edc25-f052-41a7-930e-e7ded9aa3714",
-		"name": "minecraft_bedrock_edition",
-		"description": "# Nomad Pack: flagd\n\n> [Postman Collection](https://learning.postman.com/docs/collections/collections-overview/) containing API tests to run against the Nomad API. \n  \n\n## Notes\n\n- This Collection is designed for testing the `minecraft_bedrock_edition` Pack available at [@workloads/nomad-pack-registry](https://github.com/workloads/nomad-pack-registry/tree/main/packs/minecraft_bedrock_edition).\n\n- This Collection expects Nomad to be available via `http://localhost:4646`.",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "20135",
-		"_collection_link": "https://wrklds.postman.co/workspace/Team-Workspace~6bd90753-17de-4e29-86da-52ea739451c8/collection/20135-c81edc25-f052-41a7-930e-e7ded9aa3714?action=share&creator=20135&source=collection_link"
-	},
-	"item": [
-		{
-			"name": "nomad-selfcheck",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"// map Postman Response Object to variable after parsing it as JSON",
-							"var res = pm.response.json();",
-							"res = res.config;",
-							"",
-							"// define test data, taking care to map it as closely to Nomad configuration syntax as possible",
-							"const config = {",
-							"  ACL: {",
-							"    Enabled: false,",
-							"  },",
-							"",
-							"  Client: {",
-							"    Enabled: true,",
-							"    NomadServiceDiscovery: true,",
-							"",
-							"    HostVolumes: [",
-							"        {",
-							"          Name: 'minecraft_bedrock_data',",
-							"          Path: '/tmp/minecraft_bedrock_data',",
-							"          ReadOnly: false,",
-							"        }",
-							"      ],",
-							"",
-							"      Options: {",
-							"        driver: {",
-							"          allowlist: 'docker,podman',",
-							"        },",
-							"      },",
-							"    },",
-							"",
-							"  Datacenter: pm.collectionVariables.get('datacenter'),",
-							"  DevMode: true,",
-							"  File: 'packs/' + pm.collectionVariables.get('pack') + '/tests/nomad_config.hcl',",
-							"",
-							"  Plugins: [",
-							"    {",
-							"      Name: 'docker',",
-							"    },",
-							"  ],",
-							"",
-							"  Region: pm.collectionVariables.get('region'),",
-							"",
-							"  UI: {",
-							"    Enabled: true,",
-							"  },",
-							"};",
-							"",
-							"pm.test('root configuration', function () {",
-							"  pm.expect(res.Datacenter).to.eql(config.Datacenter);",
-							"  pm.expect(res.DevMode).to.eql(config.DevMode);",
-							"  pm.expect(res.Files).to.contain(config.File);",
-							"  pm.expect(res.Region).to.eql(config.Region);",
-							"});",
-							"",
-							"pm.test('`acl` configuration', function () {",
-							"  pm.expect(res.ACL.Enabled).to.eql(config.ACL.Enabled);",
-							"});",
-							"",
-							"pm.test('`client` configuration', function () {",
-							"  pm.expect(res.Client.Enabled).to.eql(config.Client.Enabled);",
-							"  pm.expect(res.Client.HostVolumes.length).to.eql(config.Client.HostVolumes.length);",
-							"  pm.expect(res.Client.HostVolumes).to.eql(config.Client.HostVolumes);",
-							"  pm.expect(res.Client.NomadServiceDiscovery).to.eql(config.Client.NomadServiceDiscovery);",
-							"  pm.expect(res.Client.Options['driver.allowlist']).to.eql(config.Client.Options.driver.allowlist);",
-							"});",
-							"",
-							"pm.test('`plugins` configuration', function () {",
-							"  pm.expect(res.Plugins[0].Name).to.eql(config.Plugins[0].Name);",
-							"});",
-							"",
-							"pm.test('`ui` configuration', function () {",
-							"  pm.expect(res.UI.Enabled).to.eql(config.UI.Enabled);",
-							"  pm.expect(res.UI.Label).to.be.an('object').and.not.be.empty;",
-							"});",
-							"",
-							"postman.setNextRequest('nomad-job');"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{nomad_server}}/v1/agent/self",
-					"host": [
-						"{{nomad_server}}"
-					],
-					"path": [
-						"v1",
-						"agent",
-						"self"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "nomad-job",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"// map Postman Response Object to variable after parsing it as JSON",
-							"const res = pm.response.json();",
-							"",
-							"// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
-							"const config = {",
-							"  EphemeralDisk: {",
-							"    Sticky: true,",
-							"    SizeMB: 1024",
-							"  },",
-							"",
-							"  ID: pm.collectionVariables.get('job_name'),",
-							"  Namespace: pm.collectionVariables.get('namespace'),",
-							"  Priority: 99,",
-							"  Region: pm.collectionVariables.get('region'),",
-							"  ",
-							"  ReservedPorts: [",
-							"    {",
-							"      Label: 'main',",
-							"      Value: 19132,",
-							"      To: 19132,",
-							"      HostNetwork: 'default'",
-							"    },",
-							"  ],",
-							"",
-							"  ServicesCount: 1,",
-							"  Status: 'running'",
-							"};",
-							"",
-							"pm.test('root response', function () {",
-							"  pm.expect(res.ID).to.eql(config.ID);",
-							"  pm.expect(res.Namespace).to.eql(config.Namespace);",
-							"  pm.expect(res.Priority).to.eql(config.Priority);",
-							"  pm.expect(res.Region).to.eql(config.Region);",
-							"  pm.expect(res.Status).to.eql(config.Status);",
-							"});",
-							"",
-							"pm.test('`TaskGroups.EphemeralDisk` response', function () {",
-							"  pm.expect(res.TaskGroups[0].EphemeralDisk.Sticky).to.eql(config.EphemeralDisk.Sticky);",
-							"  pm.expect(res.TaskGroups[0].EphemeralDisk.SizeMB).to.eql(config.EphemeralDisk.SizeMB);",
-							"});",
-							"",
-							"// set collection variable for each service, containing provider",
-							"for (taskGroup of res.TaskGroups[0].Services) {",
-							"  pm.collectionVariables.set('service_provider_' + taskGroup.Name, taskGroup.Provider);",
-							"}",
-							"",
-							"pm.test('`TaskGroups.Networks` response', function () {",
-							"  pm.expect(res.TaskGroups[0].Networks[0].ReservedPorts).to.eql(config.ReservedPorts);",
-							"});",
-							"",
-							"pm.test('`TaskGroups.Services` response', function () {",
-							"  pm.expect(res.TaskGroups[0].Services.length).to.eql(config.ServicesCount);",
-							"});",
-							"",
-							"// pm.test('status is stable', function () {",
-							"//   pm.expect(res.Stable).to.eql(true);",
-							"// });",
-							"",
-							"postman.setNextRequest('nomad-allocation');"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disableCookies": false
-			},
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{nomad_server}}/v1/job/{{job_name}}",
-					"host": [
-						"{{nomad_server}}"
-					],
-					"path": [
-						"v1",
-						"job",
-						"{{job_name}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "nomad-allocation",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"pm.log('pre', 'Collection Variable `job_name` = `' + pm.collectionVariables.get('job_name') + '`');",
-							"",
-							"// clear previously-set `service_name` variable",
-							"pm.collectionVariables.unset('service_name');"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"// map Postman Response Object to variable after parsing it as JSON",
-							"var res = pm.response.json();",
-							"res = res[0];",
-							"",
-							"// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
-							"const config = {",
-							"  ClientStatus: 'running',",
-							"  ",
-							"  // use environment variable as set in the `nomad-job` request",
-							"  JobID: pm.collectionVariables.get('job_name'),",
-							"  Namespace: pm.collectionVariables.get('namespace')",
-							"};",
-							"",
-							"pm.test('root response', function () {",
-							"  pm.expect(res.ClientStatus).to.eql(config.ClientStatus);",
-							"  pm.expect(res.JobID).to.eql(config.JobID);",
-							"  pm.expect(res.Namespace).to.eql(config.Namespace);",
-							"});",
-							"",
-							"pm.test('`TaskStates` response', function () {",
-							"  pm.expect(res.TaskStates[config.JobID].Failed).to.eql(false);",
-							"});",
-							"",
-							"pm.test('`DeploymentStatus` response', function () {",
-							"  pm.expect(res.DeploymentStatus.Healthy).to.eql(true);",
-							"});",
-							"",
-							"// set Collection Variable `job_name` for downstream use",
-							"// replace all underscores with dashes, as per logic inside Pack template",
-							"pm.collectionVariables.set('service_name', res.JobID.split('_').join('-'));",
-							"pm.log('main', 'Collection Variable `service_name` = `' + pm.collectionVariables.get('service_name') + '`');"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disableCookies": false
-			},
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{nomad_server}}/v1/job/{{job_name}}/allocations",
-					"host": [
-						"{{nomad_server}}"
-					],
-					"path": [
-						"v1",
-						"job",
-						"{{job_name}}",
-						"allocations"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "nomad-service-main",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"const service_name = pm.collectionVariables.get('service_name');",
-							"const service_provider = pm.collectionVariables.get('service_provider_' + service_name + '-main')",
-							"",
-							"pm.log('pre', 'Collection Variable `service_name` = `' + service_name + '`');",
-							"pm.log('pre', 'Collection Variable `service_provider` = `' + service_provider + '`');",
-							"",
-							"",
-							"// check if provider is `nomad`, or skip the test:",
-							"if (service_provider == 'consul') {",
-							"  pm.log('pre', 'Service Provider is Consul, skipping test');",
-							"",
-							"  // TODO: build logic to skip test",
-							"}"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
-							"const config = {",
-							"  Datacenter: pm.collectionVariables.get('datacenter'),",
-							"  JobID: pm.collectionVariables.get('job_name'),",
-							"  Namespace: pm.collectionVariables.get('namespace'),",
-							"  Port: 19132,",
-							"",
-							"  // use environment variable as set in the `nomad-allocation` request",
-							"  ServiceName: pm.collectionVariables.get('service_name') + '-main',",
-							"",
-							"  Tags: [",
-							"    'minecraft',",
-							"    'minecraft-bedrock-edition',",
-							"  ]",
-							"};",
-							"",
-							"// map Postman Response Object to variable after parsing it as JSON",
-							"var res = pm.response.json();",
-							"res = res[0];",
-							"",
-							"pm.test('root response', function () {",
-							"  pm.expect(res.Datacenter).to.eql(config.Datacenter);",
-							"  pm.expect(res.JobID).to.eql(config.JobID);",
-							"  pm.expect(res.Namespace).to.eql(config.Namespace);  ",
-							"  pm.expect(res.Port).to.eql(config.Port);",
-							"  pm.expect(res.ServiceName).to.eql(config.ServiceName);",
-							"  pm.expect(res.Tags).to.eql(config.Tags);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disableCookies": false
-			},
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{nomad_server}}/v1/service/{{service_name}}-main",
-					"host": [
-						"{{nomad_server}}"
-					],
-					"path": [
-						"v1",
-						"service",
-						"{{service_name}}-main"
-					]
-				}
-			},
-			"response": []
-		}
-	],
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					"Object.prototype.log = (stage, message) => {",
-					"  // add collection and request names as prefix:",
-					"  var prefix = '[' + pm.collectionVariables.get('pack') + ':' + pm.info.requestName + `:${stage}] `;",
-					"",
-					"  console.info(prefix + `${message}`);",
-					"};"
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		}
-	],
-	"variable": [
-		{
-			"key": "datacenter",
-			"value": "testing",
-			"type": "string"
-		},
-		{
-			"key": "job_name",
-			"value": "minecraft",
-			"type": "string"
-		},
-		{
-			"key": "namespace",
-			"value": "default",
-			"type": "string"
-		},
-		{
-			"key": "nomad_server",
-			"value": "http://localhost:4646",
-			"type": "string"
-		},
-		{
-			"key": "pack",
-			"value": "minecraft_bedrock_edition",
-			"type": "string"
-		},
-		{
-			"key": "region",
-			"value": "global",
-			"type": "string"
-		},
-		{
-			"key": "service_provider_minecraft-main",
-			"value": ""
-		},
-		{
-			"key": "service_name",
-			"value": ""
-		}
-	]
+  "info": {
+    "_postman_id": "2559ed96-63a6-4a8b-b2a7-1bd19ba0cbf1",
+    "name": "flagd",
+    "description": "# Nomad Pack: flagd\n\n> [Postman Collection](https://learning.postman.com/docs/collections/collections-overview/) containing API tests to run against the Nomad API. \n  \n\n## Notes\n\n- This Collection is designed for testing the `flagd` Pack available at [@workloads/nomad-pack-registry](https://github.com/workloads/nomad-pack-registry/tree/main/packs/flagd).\n\n- This Collection expects Nomad to be available via `http://localhost:4646`.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "20135",
+    "_collection_link": "https://wrklds.postman.co/workspace/Team-Workspace~6bd90753-17de-4e29-86da-52ea739451c8/collection/20135-2559ed96-63a6-4a8b-b2a7-1bd19ba0cbf1?action=share&source=collection_link&creator=20135"
+  },
+  "item": [
+    {
+      "name": "nomad-selfcheck",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "// map Postman Response Object to variable after parsing it as JSON",
+              "var res = pm.response.json();",
+              "res = res.config;",
+              "",
+              "// define test data, taking care to map it as closely to Nomad configuration syntax as possible",
+              "const config = {",
+              "  ACL: {",
+              "    Enabled: false,",
+              "  },",
+              "",
+              "  Client: {",
+              "    Enabled: true,",
+              "    NomadServiceDiscovery: true,",
+              "",
+              "    Options: {",
+              "      driver: {",
+              "        allowlist: 'docker,podman',",
+              "      },",
+              "    },",
+              "  },",
+              "",
+              "  Datacenter: pm.collectionVariables.get('datacenter'),",
+              "  DevMode: true,",
+              "",
+              "  // The `rcon_web` Pack is primarily designed to be used with the `minecraft_java_server` and `minecraft_bedrock` Packs.",
+              "  // As such, the config file would be one with a path to either of those Packs, making this test fail. ",
+              "  // To prevent false positives, this test is not currently active.",
+              "  //File: 'packs/' + pm.collectionVariables.get('pack') + '/tests/config.hcl',",
+              "",
+              "  Plugins: [",
+              "    {",
+              "      Name: 'docker',",
+              "    },",
+              "  ],",
+              "",
+              "  Region: pm.collectionVariables.get('region'),",
+              "",
+              "  UI: {",
+              "    Enabled: true,",
+              "  },",
+              "};",
+              "",
+              "pm.test('root configuration', function () {",
+              "  pm.expect(res.Datacenter).to.eql(config.Datacenter);",
+              "  pm.expect(res.DevMode).to.eql(config.DevMode);",
+              "",
+              "  // The `rcon_web` Pack is primarily designed to be used with the `minecraft_java_server` and `minecraft_bedrock` Packs.",
+              "  // As such, the config file would be one with a path to either of those Packs, making this test fail. ",
+              "  // To prevent false positives, this test is not currently active.",
+              "  // pm.expect(res.Files).to.contain(config.File);",
+              "",
+              "  pm.expect(res.Region).to.eql(config.Region);",
+              "});",
+              "",
+              "pm.test('`acl` configuration', function () {",
+              "  pm.expect(res.ACL.Enabled).to.eql(config.ACL.Enabled);",
+              "});",
+              "",
+              "pm.test('`client` configuration', function () {",
+              "  pm.expect(res.Client.Enabled).to.eql(config.Client.Enabled);",
+              "  pm.expect(res.Client.NomadServiceDiscovery).to.eql(config.Client.NomadServiceDiscovery);",
+              "  pm.expect(res.Client.Options['driver.allowlist']).to.eql(config.Client.Options.driver.allowlist);",
+              "});",
+              "",
+              "pm.test('`plugins` configuration', function () {",
+              "  pm.expect(res.Plugins[0].Name).to.eql(config.Plugins[0].Name);",
+              "});",
+              "",
+              "pm.test('`ui` configuration', function () {",
+              "  pm.expect(res.UI.Enabled).to.eql(config.UI.Enabled);",
+              "  pm.expect(res.UI.Label).to.be.an('object').and.not.be.empty;",
+              "});",
+              "",
+              "// set Collection Variable `app_host` for downstream use",
+              "pm.collectionVariables.set('app_host', res.BindAddr);",
+              "pm.log('main', 'Collection Variable `app_host` = `' + pm.collectionVariables.get('app_host') + '`');",
+              "",
+              "postman.setNextRequest('nomad-jobs');"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{server}}/v1/agent/self",
+          "host": [
+            "{{server}}"
+          ],
+          "path": [
+            "v1",
+            "agent",
+            "self"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "nomad-jobs",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "// map Postman Response Object to variable after parsing it as JSON",
+              "var res = pm.response.json();",
+              "res = res[0];",
+              "",
+              "// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
+              "const config = {",
+              "  ID: pm.collectionVariables.get('pack'),",
+              "  Namespace: pm.collectionVariables.get('namespace'),",
+              "  Status: 'running',",
+              "};",
+              "",
+              "pm.test('root configuration', function () {",
+              "  pm.expect(res.ID).to.eql(config.ID);",
+              "  pm.expect(res.Namespace).to.eql(config.Namespace);",
+              "  pm.expect(res.Status).to.eql(config.Status);",
+              "});",
+              "",
+              "// set Collection Variable `job_name` for downstream use",
+              "pm.collectionVariables.set('job_name', res.ID);",
+              "pm.log('main', 'Collection Variable `job_name` = `' + pm.collectionVariables.get('job_name') + '`');",
+              "",
+              "postman.setNextRequest('nomad-job');"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "// clear previously-set `job_name` variable",
+              "pm.collectionVariables.unset('job_name');"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "protocolProfileBehavior": {
+        "disableCookies": false
+      },
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{server}}/v1/jobs?prefix={{pack}}",
+          "host": [
+            "{{server}}"
+          ],
+          "path": [
+            "v1",
+            "jobs"
+          ],
+          "query": [
+            {
+              "key": "prefix",
+              "value": "{{pack}}"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "nomad-job",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "// map Postman Response Object to variable after parsing it as JSON",
+              "const res = pm.response.json();",
+              "",
+              "// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
+              "const config = {",
+              "  EphemeralDisk: {",
+              "    Sticky: true,",
+              "    SizeMB: 128",
+              "  },",
+              "",
+              "  ID: pm.collectionVariables.get('job_name'),",
+              "  Namespace: pm.collectionVariables.get('namespace'),",
+              "  Priority: 10,",
+              "  Region: pm.collectionVariables.get('region'),",
+              "  ",
+              "  ReservedPorts: [",
+              "    {",
+              "      Label: 'health',",
+              "      Value: parseInt(pm.collectionVariables.get('health_port')),",
+              "      To: parseInt(pm.collectionVariables.get('health_port')),",
+              "      HostNetwork: 'default'",
+              "    }, {",
+              "      Label: 'main',",
+              "      Value: parseInt(pm.collectionVariables.get('app_port')),",
+              "      To: parseInt(pm.collectionVariables.get('app_port')),",
+              "      HostNetwork: 'default'",
+              "    }, ",
+              "  ],",
+              "",
+              "  Status: 'running'",
+              "};",
+              "",
+              "pm.test('root response', function () {",
+              "  pm.expect(res.ID).to.eql(config.ID);",
+              "  pm.expect(res.Namespace).to.eql(config.Namespace);",
+              "  pm.expect(res.Priority).to.eql(config.Priority);",
+              "  pm.expect(res.Region).to.eql(config.Region);",
+              "  pm.expect(res.Status).to.eql(config.Status);",
+              "});",
+              "",
+              "pm.test('`TaskGroups.EphemeralDisk` response', function () {",
+              "  pm.expect(res.TaskGroups[0].EphemeralDisk.Sticky).to.eql(config.EphemeralDisk.Sticky);",
+              "  pm.expect(res.TaskGroups[0].EphemeralDisk.SizeMB).to.eql(config.EphemeralDisk.SizeMB);",
+              "});",
+              "",
+              "pm.test('`TaskGroups.Networks` response', function () {",
+              "  pm.expect(res.TaskGroups[0].Networks[0].ReservedPorts).to.eql(config.ReservedPorts);",
+              "});",
+              "",
+              "pm.test('status is stable', function () {",
+              "  pm.expect(res.Stable).to.eql(true);",
+              "});",
+              "",
+              "postman.setNextRequest('nomad-allocation');"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "protocolProfileBehavior": {
+        "disableCookies": false
+      },
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{server}}/v1/job/{{job_name}}",
+          "host": [
+            "{{server}}"
+          ],
+          "path": [
+            "v1",
+            "job",
+            "{{job_name}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "nomad-allocation",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "pm.log('pre', 'Collection Variable `job_name` = `' + pm.collectionVariables.get('job_name') + '`');",
+              "",
+              "// clear previously-set `service_name` variable",
+              "pm.collectionVariables.unset('service_name');"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "// map Postman Response Object to variable after parsing it as JSON",
+              "var res = pm.response.json();",
+              "res = res[0];",
+              "",
+              "// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
+              "const config = {",
+              "  ClientStatus: 'running',",
+              "  ",
+              "  // use environment variable as set in the `nomad-job` request",
+              "  JobID: pm.collectionVariables.get('job_name'),",
+              "  Namespace: pm.collectionVariables.get('namespace')",
+              "};",
+              "",
+              "pm.test('root response', function () {",
+              "  pm.expect(res.ClientStatus).to.eql(config.ClientStatus);",
+              "  pm.expect(res.JobID).to.eql(config.JobID);",
+              "  pm.expect(res.Namespace).to.eql(config.Namespace);",
+              "});",
+              "",
+              "pm.test('`TaskStates` response', function () {",
+              "  pm.expect(res.TaskStates[config.JobID].Failed).to.eql(false);",
+              "});",
+              "",
+              "pm.test('`DeploymentStatus` response', function () {",
+              "  pm.expect(res.DeploymentStatus.Healthy).to.eql(true);",
+              "});",
+              "",
+              "// set Collection Variable `job_name` for downstream use",
+              "// replace all underscores with dashes, as per logic inside Pack template",
+              "pm.collectionVariables.set('service_name', res.JobID.split('_').join('-'));",
+              "pm.log('main', 'Collection Variable `service_name` = `' + pm.collectionVariables.get('service_name') + '`');",
+              "",
+              "postman.setNextRequest('nomad-service');"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "protocolProfileBehavior": {
+        "disableCookies": false
+      },
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{server}}/v1/job/{{job_name}}/allocations",
+          "host": [
+            "{{server}}"
+          ],
+          "path": [
+            "v1",
+            "job",
+            "{{job_name}}",
+            "allocations"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "nomad-service-health",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "pm.log('pre', 'Collection Variable `service_name` = `' + pm.collectionVariables.get('service_name') + '`');"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
+              "const config = {",
+              "  Datacenter: pm.collectionVariables.get('datacenter'),",
+              "  JobID: pm.collectionVariables.get('job_name'),",
+              "  Namespace: pm.collectionVariables.get('namespace'),",
+              "  Port: parseInt(pm.collectionVariables.get('health_port')),",
+              "",
+              "  // use environment variable as set in the `nomad-allocation` request",
+              "  ServiceName: pm.collectionVariables.get('service_name') + '-health',",
+              "",
+              "  Tags: [",
+              "    pm.collectionVariables.get('service_name')",
+              "  ]",
+              "};",
+              "",
+              "// map Postman Response Object to variable after parsing it as JSON",
+              "var res = pm.response.json();",
+              "res = res[0];",
+              "",
+              "pm.test('root response', function () {",
+              "  pm.expect(res.Datacenter).to.eql(config.Datacenter);",
+              "  pm.expect(res.JobID).to.eql(config.JobID);",
+              "  pm.expect(res.Namespace).to.eql(config.Namespace);  ",
+              "  pm.expect(res.Port).to.eql(config.Port);",
+              "  pm.expect(res.ServiceName).to.eql(config.ServiceName);",
+              "  pm.expect(res.Tags).to.eql(config.Tags);",
+              "});",
+              "",
+              "postman.setNextRequest(null);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true,
+        "disableCookies": false
+      },
+      "request": {
+        "method": "GET",
+        "header": [],
+        "body": {
+          "mode": "urlencoded",
+          "urlencoded": [
+            {
+              "key": "filter",
+              "value": "JobID contains '{{job_name}}'",
+              "description": "Filter on JobID, see https://developer.hashicorp.com/nomad/api-docs#filtering",
+              "type": "text"
+            }
+          ]
+        },
+        "url": {
+          "raw": "{{server}}/v1/service/{{service_name}}-health",
+          "host": [
+            "{{server}}"
+          ],
+          "path": [
+            "v1",
+            "service",
+            "{{service_name}}-health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "nomad-service-main",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "pm.log('pre', 'Collection Variable `service_name` = `' + pm.collectionVariables.get('service_name') + '`');"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
+              "const config = {",
+              "  Datacenter: pm.collectionVariables.get('datacenter'),",
+              "  JobID: pm.collectionVariables.get('job_name'),",
+              "  Namespace: pm.collectionVariables.get('namespace'),",
+              "  Port: parseInt(pm.collectionVariables.get('app_port')),",
+              "",
+              "  // use environment variable as set in the `nomad-allocation` request",
+              "  ServiceName: pm.collectionVariables.get('service_name') + '-main',",
+              "",
+              "  Tags: [",
+              "    pm.collectionVariables.get('service_name')",
+              "  ]",
+              "};",
+              "",
+              "// map Postman Response Object to variable after parsing it as JSON",
+              "var res = pm.response.json();",
+              "res = res[0];",
+              "",
+              "pm.test('root response', function () {",
+              "  pm.expect(res.Datacenter).to.eql(config.Datacenter);",
+              "  pm.expect(res.JobID).to.eql(config.JobID);",
+              "  pm.expect(res.Namespace).to.eql(config.Namespace);  ",
+              "  pm.expect(res.Port).to.eql(config.Port);",
+              "  pm.expect(res.ServiceName).to.eql(config.ServiceName);",
+              "  pm.expect(res.Tags).to.eql(config.Tags);",
+              "});",
+              "",
+              "// set Collection Variable `app_port` for downstream use",
+              "pm.collectionVariables.set('app_port', res.Port);",
+              "pm.log('main', 'Collection Variable `app_port` = `' + pm.collectionVariables.get('app_port') + '`');",
+              "",
+              "postman.setNextRequest('nomad-service-websocket');"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true,
+        "disableCookies": false
+      },
+      "request": {
+        "method": "GET",
+        "header": [],
+        "body": {
+          "mode": "urlencoded",
+          "urlencoded": [
+            {
+              "key": "filter",
+              "value": "JobID contains '{{job_name}}'",
+              "description": "Filter on JobID, see https://developer.hashicorp.com/nomad/api-docs#filtering",
+              "type": "text"
+            }
+          ]
+        },
+        "url": {
+          "raw": "{{server}}/v1/service/{{service_name}}-main",
+          "host": [
+            "{{server}}"
+          ],
+          "path": [
+            "v1",
+            "service",
+            "{{service_name}}-main"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "Object.prototype.log = (stage, message) => {",
+          "  // add collection and request names as prefix:",
+          "  var prefix = '[' + pm.collectionVariables.get('pack') + ':' + pm.info.requestName + `:${stage}] `;",
+          "",
+          "  console.info(prefix + `${message}`);",
+          "};"
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "datacenter",
+      "value": "testing",
+      "type": "string"
+    },
+    {
+      "key": "namespace",
+      "value": "default",
+      "type": "string"
+    },
+    {
+      "key": "pack",
+      "value": "flagd",
+      "type": "string"
+    },
+    {
+      "key": "region",
+      "value": "global",
+      "type": "string"
+    },
+    {
+      "key": "server",
+      "value": "http://localhost:4646",
+      "type": "string"
+    },
+    {
+      "key": "service_name",
+      "value": "flagd"
+    },
+    {
+      "key": "app_port",
+      "value": "8013"
+    },
+    {
+      "key": "job_name",
+      "value": "flagd"
+    },
+    {
+      "key": "health_port",
+      "value": "8014",
+      "type": "string"
+    },
+    {
+      "key": "app_host",
+      "value": ""
+    }
+  ]
 }

--- a/packs/flagd/tests/newman.json
+++ b/packs/flagd/tests/newman.json
@@ -206,7 +206,7 @@
               "// define test data, taking care to map it as closely to Nomad Job configuration syntax as possible",
               "const config = {",
               "  EphemeralDisk: {",
-              "    Sticky: true,",
+              "    Sticky: false,",
               "    SizeMB: 128",
               "  },",
               "",

--- a/packs/flagd/tests/nomad_config.hcl
+++ b/packs/flagd/tests/nomad_config.hcl
@@ -20,12 +20,6 @@ acl {
 client {
   enabled = true
 
-  # see https://developer.hashicorp.com/nomad/docs/configuration/client#host_volume
-  host_volume "flagd_config" {
-    path      = "/tmp/flagd_config"
-    read_only = false
-  }
-
   # see https://developer.hashicorp.com/nomad/docs/configuration/client#network_interface
   network_interface = "{{ GetDefaultInterfaces | attr \"name\" }}"
 

--- a/packs/flagd/tests/nomad_config.hcl
+++ b/packs/flagd/tests/nomad_config.hcl
@@ -1,0 +1,96 @@
+# minimally viable configuration for a Nomad Server that can run `minecraft_java_edition`
+# requires `docker` to be installed and running on the host machine
+
+# see https://developer.hashicorp.com/nomad/docs/configuration#data_dir
+data_dir = "/tmp/"
+
+# see https://developer.hashicorp.com/nomad/docs/configuration#datacenter
+datacenter = "testing"
+
+# see https://developer.hashicorp.com/nomad/docs/configuration#region
+region = "global"
+
+# see https://developer.hashicorp.com/nomad/docs/configuration/acl
+acl {
+  # testing this Pack does not require ACLs to be enabled
+  enabled = false
+}
+
+# see https://developer.hashicorp.com/nomad/docs/configuration/client
+client {
+  enabled = true
+
+  # see https://developer.hashicorp.com/nomad/docs/configuration/client#host_volume
+  host_volume "flagd_config" {
+    path      = "/tmp/flagd_config"
+    read_only = false
+  }
+
+  # see https://developer.hashicorp.com/nomad/docs/configuration/client#network_interface
+  network_interface = "{{ GetDefaultInterfaces | attr \"name\" }}"
+
+  # see https://developer.hashicorp.com/nomad/docs/configuration/client#options-parameters
+  options = {
+    # see https://developer.hashicorp.com/nomad/docs/configuration/client#driver-allowlist
+    "driver.allowlist" = "docker,podman"
+  }
+}
+
+# see https://developer.hashicorp.com/nomad/docs/drivers/docker
+plugin "docker" {
+  # see https://developer.hashicorp.com/nomad/docs/drivers/docker#allow_privileged
+  allow_privileged = false
+
+  # see https://developer.hashicorp.com/nomad/docs/drivers/docker#plugin-options
+  config {
+    # see https://developer.hashicorp.com/nomad/docs/drivers/docker#extra_labels
+    extra_labels = [
+      "nomad_job_name",
+      "job_id",
+      "task_name",
+    ]
+
+    # see https://developer.hashicorp.com/nomad/docs/drivers/docker#gc
+    gc {
+      image       = true
+      image_delay = "3m"
+      container   = true
+
+      dangling_containers {
+        enabled        = true
+        dry_run        = false
+        period         = "5m"
+        creation_grace = "5m"
+      }
+    }
+
+    # see https://developer.hashicorp.com/nomad/docs/drivers/docker#volumes-1
+    volumes {
+      enabled = true
+    }
+  }
+}
+
+# see https://developer.hashicorp.com/nomad/docs/configuration/server
+server {
+  enabled          = true
+  bootstrap_expect = 1
+}
+
+# see https://developer.hashicorp.com/nomad/docs/configuration/telemetry
+telemetry {
+  publish_allocation_metrics = true
+  publish_node_metrics       = true
+}
+
+# see https://developer.hashicorp.com/nomad/docs/configuration/ui
+ui {
+  enabled = true
+
+  # see https://developer.hashicorp.com/nomad/docs/configuration/ui#label-parameters
+  label {
+    text             = "⚠️ Testing Environment for the `flagd` Nomad Pack."
+    background_color = "#00000"
+    text_color       = "#ffffff"
+  }
+}

--- a/packs/flagd/variables.hcl
+++ b/packs/flagd/variables.hcl
@@ -1,0 +1,297 @@
+#######################################
+## Application-specific Configuration #
+#######################################
+
+# see https://flagd.dev/reference/sync-configuration/#uri-patterns
+variable "app_source_uri" {
+  type        = string
+  description = "Source URI to serve."
+  default     = "http:https://raw.githubusercontent.com/open-feature/flagd/main/samples/example_flags.flagd.json"
+
+  # TODO: add validation and split on `:`; allowed values are `kubernetes`, `file`, `http`, and `grcp`
+}
+
+###############################
+## Pack-specifc Configuration #
+###############################
+
+variable "nomad_pack_verbose_output" {
+  type        = bool
+  description = "Toggle to enable verbose output."
+  default     = true
+}
+
+#####################################
+## Nomad Job-specific Configuration #
+#####################################
+
+# see https://developer.hashicorp.com/nomad/docs/concepts/architecture#datacenters
+variable "nomad_job_datacenters" {
+  type        = list(string)
+  description = "Eligible Datacenters for the Job."
+
+  default = [
+    "*"
+  ]
+}
+
+variable "nomad_job_name" {
+  type        = string
+  description = "Name for the Job."
+
+  # value will be truncated to 63 characters when necessary
+  default = "flagd"
+}
+
+# see https://developer.hashicorp.com/nomad/docs/job-specification/job#namespace
+variable "nomad_job_namespace" {
+  type        = string
+  description = "Namespace for the Job."
+  default     = "default"
+}
+
+# see https://developer.hashicorp.com/nomad/docs/job-specification/job#priority
+variable "nomad_job_priority" {
+  type        = number
+  description = "Priority for the Job."
+  default     = 10
+}
+
+# see https://developer.hashicorp.com/nomad/docs/concepts/architecture#regions
+variable "nomad_job_region" {
+  type        = string
+  description = "Region for the Job."
+  default     = "global"
+}
+
+variable "nomad_group_count" {
+  type        = number
+  description = "Count of Deployments for the Group."
+  default     = 1
+}
+
+# see https://developer.hashicorp.com/nomad/docs/job-specification/ephemeral_disk
+variable "nomad_group_ephemeral_disk" {
+  type = object({
+    migrate = bool
+    size    = number
+    sticky  = bool
+  })
+
+  description = "Ephemeral Disk Configuration for the Group."
+
+  default = {
+    # make best-effort attempt to migrate data to a different node if no placement is possible on the original node.
+    migrate = true
+
+    # size of the ephemeral disk in MB
+    size = 128
+
+    # make best-effort attempt to place an updated allocation on the same node.
+    sticky = true
+  }
+}
+
+variable "nomad_group_name" {
+  type        = string
+  description = "Name for the Group."
+  default     = "flagd"
+}
+
+# see https://developer.hashicorp.com/nomad/docs/job-specification/network#network-modes
+variable "nomad_group_network_mode" {
+  type        = string
+  description = "Network Mode for the Group."
+  default     = "host"
+}
+
+variable "nomad_group_ports" {
+  type = map(object({
+    name           = string
+    path           = string
+    port           = number
+    type           = string
+    host_network   = string
+    check_interval = string
+    check_timeout  = string
+  }))
+
+  description = "Port Configuration for the Group."
+
+  default = {
+    # port for flagd API
+    main = {
+      name           = "flagd_main"
+      path           = "/"
+      port           = 8013
+      type           = "http"
+      host_network   = null
+      check_interval = "30s"
+      check_timeout  = "15s"
+    },
+
+    # port for flagd Healthchecks
+    # see https://flagd.dev/reference/monitoring/?h=health#http
+    health = {
+      name           = "flagd_health"
+      path           = "/healthz"
+      port           = 8014
+      type           = "http"
+      host_network   = null
+      check_interval = "30s"
+      check_timeout  = "15s"
+    },
+  }
+}
+
+variable "nomad_group_restart_logic" {
+  type = object({
+    attempts = number
+    interval = string
+    delay    = string
+    mode     = string
+  })
+
+  description = "Restart Logic for the Group."
+
+  default = {
+    attempts = 3
+    interval = "120s"
+    delay    = "30s"
+    mode     = "fail"
+  }
+}
+
+variable "nomad_group_service_name_prefix" {
+  type        = string
+  description = "Name of the Service for the Group."
+  default     = "flagd"
+}
+
+variable "nomad_group_service_provider" {
+  type        = string
+  description = "Provider of the Service for the Group."
+  default     = "nomad"
+}
+
+variable "nomad_group_tags" {
+  type        = list(string)
+  description = "List of Tags for the Group."
+
+  default = [
+    "flagd",
+  ]
+}
+
+variable "nomad_group_volumes" {
+  type = map(object({
+    name        = string
+    type        = string
+    destination = string
+    read_only   = bool
+  }))
+
+  description = "Volumes for the Group."
+
+  default = {
+    flagd_config = {
+      name        = "flagd_config",
+      type        = "host"
+      destination = "/etc/flagd"
+      read_only   = false
+    },
+  }
+}
+
+# see https://developer.hashicorp.com/nomad/docs/drivers/docker#args
+variable "nomad_task_args" {
+  type        = list(string)
+  description = "Arguments to pass to the Task."
+
+  default = [
+    "--config",
+    "/nomad/local/flagd.yml",
+  ]
+}
+
+# see https://developer.hashicorp.com/nomad/docs/drivers/docker#args
+variable "nomad_task_command" {
+  type        = string
+  description = "Command to pass to the Task."
+
+  # see https://flagd.dev/quick-start/#start-flagd
+  default = "start"
+}
+
+variable "nomad_task_driver" {
+  type        = string
+  description = "Driver to use for the Task."
+  default     = "docker"
+}
+
+variable "nomad_task_image" {
+  type = object({
+    registry  = string
+    namespace = string
+    image     = string
+    tag       = string
+    digest    = string
+  })
+
+  description = "Content Address to use for the Container Image for the Task."
+
+  # see https://github.com/open-feature/flagd/pkgs/container/flagd
+  default = {
+    # Container Registry URL where the Image is hosted
+    registry = "ghcr.io"
+
+    # Namespace of the Image
+    namespace = "open-feature"
+
+    # Slug of the Image
+    image = "flagd"
+
+    # Tag of the Image
+    tag = "v0.6.7"
+
+    # Digest of the Tag of the Image
+    digest = "sha256:bc771a0e42089111784f06168238304212c9f22c9b472934de5d4bd742a09a81"
+  }
+}
+
+variable "nomad_task_name" {
+  type        = string
+  description = "Name for the Task."
+  default     = "flagd"
+}
+
+# see https://developer.hashicorp.com/nomad/docs/job-specification/resources
+variable "nomad_task_resources" {
+  type = object({
+    cpu        = number
+    cores      = number
+    memory     = number
+    memory_max = number
+  })
+
+  description = "Resource Limits for the Task."
+
+  default = {
+    # Tasks can ask for `cpu` or `cores`, not both.
+    # value in MHz
+    cpu = 512
+
+    # Tasks can ask for `cpu` or `cores`, not both.
+    # see https://developer.hashicorp.com/nomad/docs/job-specification/resources#cores
+    # and https://developer.hashicorp.com/nomad/docs/drivers/docker#cpu
+    cores = null
+
+    # value in MB
+    memory = 64
+
+    # value in MB
+    # see https://developer.hashicorp.com/nomad/docs/job-specification/resources#memory-oversubscription
+    # and https://developer.hashicorp.com/nomad/docs/drivers/docker#memory
+    memory_max = 512
+  }
+}

--- a/packs/flagd/variables.hcl
+++ b/packs/flagd/variables.hcl
@@ -74,14 +74,12 @@ variable "nomad_group_ephemeral_disk" {
   description = "Ephemeral Disk Configuration for the Group."
 
   default = {
-    # make best-effort attempt to migrate data to a different node if no placement is possible on the original node.
-    migrate = true
+    migrate = false
 
     # size of the ephemeral disk in MB
-    size = 128
+    size = 16
 
-    # make best-effort attempt to place an updated allocation on the same node.
-    sticky = true
+    sticky = false
   }
 }
 

--- a/packs/flagd/variables.hcl
+++ b/packs/flagd/variables.hcl
@@ -77,7 +77,7 @@ variable "nomad_group_ephemeral_disk" {
     migrate = false
 
     # size of the ephemeral disk in MB
-    size = 16
+    size = 128
 
     sticky = false
   }
@@ -112,7 +112,7 @@ variable "nomad_group_ports" {
   description = "Port Configuration for the Group."
 
   default = {
-    # port for flagd API
+    # port for flagd
     main = {
       check_interval = "30s"
       check_timeout  = "15s"
@@ -125,7 +125,7 @@ variable "nomad_group_ports" {
       type           = "http"
     },
 
-    # port for flagd Healthchecks
+    # port for flagd healthcheck
     # see https://flagd.dev/reference/monitoring/?h=health#http
     health = {
       check_interval = "30s"


### PR DESCRIPTION
This PR introduces a Pack for `flagd.dev`.

It is built with `v2` parsing in mind and should be ran using the latest `nightly` or `0.1.0` and onwards.